### PR TITLE
import error on newest pypy on push (with hg-git resp. dulwich as extension)

### DIFF
--- a/mercurial/demandimport.py
+++ b/mercurial/demandimport.py
@@ -109,6 +109,11 @@ class _demandmod(object):
         self._load()
         setattr(self._module, attr, val)
 
+try:
+    import __pypy__
+except ImportError:
+    __pypy__ = None
+
 def _demandimport(name, globals=None, locals=None, fromlist=None, level=level):
     if not locals or name in ignore or fromlist == ('*',):
         # these cases we can't really delay
@@ -127,6 +132,10 @@ def _demandimport(name, globals=None, locals=None, fromlist=None, level=level):
                 return locals[base]
         return _demandmod(name, globals, locals, level)
     else:
+        
+        if __pypy__ is not None and name.startswith('_ctypes.'):
+            return _hgextimport(_import, name, globals, locals, fromlist, level)
+
         if level != -1:
             # from . import b,c,d or from .a import b,c,d
             return _origimport(name, globals, locals, fromlist, level)

--- a/mercurial/hgweb/hgwebdir_mod.py
+++ b/mercurial/hgweb/hgwebdir_mod.py
@@ -356,6 +356,7 @@ class hgwebdir(object):
 
                 contact = get_contact(get)
                 description = get("web", "description", "")
+                seenrepos.add(name)
                 name = get("web", "name", name)
                 row = {'contact': contact or "unknown",
                        'contact_sort': contact.upper() or "unknown",
@@ -370,7 +371,6 @@ class hgwebdir(object):
                        'isdirectory': None,
                        }
 
-                seenrepos.add(name)
                 yield row
 
         sortdefault = None, False

--- a/tests/test-hgwebdir.t
+++ b/tests/test-hgwebdir.t
@@ -56,6 +56,13 @@ create a subdirectory containing repositories and subrepositories
   $ echo f2 > f/f2/f2
   $ hg --cwd f/f2 ci -Amf2 -d '4 0'
   adding f2
+  $ echo 'f2 = f2' > f/.hgsub
+  $ hg -R f ci -Am 'add subrepo' -d'4 0'
+  adding .hgsub
+  $ cat >> f/.hg/hgrc << EOF
+  > [web]
+  > name = fancy name for repo f
+  > EOF
   $ cd ..
 
 create repository without .hg/store
@@ -305,7 +312,7 @@ should succeed, slashy names
   </tr>
   
   <tr>
-  <td><a href="/coll/notrepo/f/?style=paper">coll/notrepo/f</a></td>
+  <td><a href="/coll/notrepo/f/?style=paper">fancy name for repo f</a></td>
   <td>unknown</td>
   <td>&#70;&#111;&#111;&#32;&#66;&#97;&#114;&#32;&#60;&#102;&#111;&#111;&#46;&#98;&#97;&#114;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;&#62;</td>
   <td class="age">*</td> (glob)
@@ -409,7 +416,7 @@ should succeed, slashy names
   </tr>
   
   <tr>
-  <td><a href="/rcoll/notrepo/f/?style=paper">rcoll/notrepo/f</a></td>
+  <td><a href="/rcoll/notrepo/f/?style=paper">fancy name for repo f</a></td>
   <td>unknown</td>
   <td>&#70;&#111;&#111;&#32;&#66;&#97;&#114;&#32;&#60;&#102;&#111;&#111;&#46;&#98;&#97;&#114;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;&#62;</td>
   <td class="age">*</td> (glob)
@@ -500,7 +507,7 @@ should succeed, slashy names
   </tr>
   
   <tr>
-  <td><a href="/star/webdir/notrepo/f/?style=paper">star/webdir/notrepo/f</a></td>
+  <td><a href="/star/webdir/notrepo/f/?style=paper">fancy name for repo f</a></td>
   <td>unknown</td>
   <td>&#70;&#111;&#111;&#32;&#66;&#97;&#114;&#32;&#60;&#102;&#111;&#111;&#46;&#98;&#97;&#114;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;&#62;</td>
   <td class="age">*</td> (glob)
@@ -604,7 +611,7 @@ should succeed, slashy names
   </tr>
   
   <tr>
-  <td><a href="/starstar/webdir/notrepo/f/?style=paper">starstar/webdir/notrepo/f</a></td>
+  <td><a href="/starstar/webdir/notrepo/f/?style=paper">fancy name for repo f</a></td>
   <td>unknown</td>
   <td>&#70;&#111;&#111;&#32;&#66;&#97;&#114;&#32;&#60;&#102;&#111;&#111;&#46;&#98;&#97;&#114;&#64;&#101;&#120;&#97;&#109;&#112;&#108;&#101;&#46;&#99;&#111;&#109;&#62;</td>
   <td class="age">*</td> (glob)
@@ -900,6 +907,7 @@ Test collapse = True
   $ cat >> paths.conf <<EOF
   > [web]
   > collapse=true
+  > descend = true
   > EOF
   $ hg serve -p $HGPORT1 -d --pid-file=hg.pid --webdir-conf paths.conf \
   >     -A access-paths.log -E error-paths-3.log


### PR DESCRIPTION
ImportError: No module named _Pointer;

demand import of statements like "from _ctypes.pointer import _Pointer, as_ffi_pointer" will fail
through using of "_Pointer" inside this modules;
just load _ctypes.\* directly for pypy;
## 

```
Python 2.7.9 (9c4588d731b7, Mar 23 2015, 20:00:36)
[PyPy 2.5.1 with MSC v.1500 32 bit] on win32
...
  File ".../mercurial/mercurial/demandimport.py", line 47, in _hgextimport
    return importfunc(name, globals, *args)
ImportError: No module named _Pointer
abort: No module named _Pointer!
```
